### PR TITLE
Provide default opkg conf path

### DIFF
--- a/src/Main.cpp.in
+++ b/src/Main.cpp.in
@@ -77,7 +77,7 @@ static std::string s_archIndexFilePath = "/etc/opkg/arch.conf";
 
 static std::string s_command;
 static std::string s_package;
-static std::string s_conf;
+static std::string s_conf = "/etc/opkg/opkg.conf";
 static bool        s_useSysLog = true;
 
 static int 		   s_cleanupCode = 3;			//0 = clean up nothing, 1 = clean up target package , 2 = clean up temp dir   (bitfield)


### PR DESCRIPTION
If the "-f" option isn't provided by the caller, the current code will
provide an empty "-f" option to opkg, leading to installation failure.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>